### PR TITLE
test node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - npm install -g grunt-cli
 
 install:
-  - yarn
+  - yarn install
 
 script: grunt deploy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 8.9.1
+  - 12
 
 before_install:
   - export TZ=Canada/Eastern

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - 8.9.1
   - 12
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - 8.9.1
+  - 10
   - 12
 
 before_install:

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "grunt-contrib-uglify": "~0.3.1",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-docco": "^0.3.3",
-    "grunt-eco": "*",
+    "grunt-eco": "0.2.0-rc.0",
     "grunt-exec": "^0.4.6",
     "grunt-markdown": "~0.7.0",
     "grunt-mocha": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "yarn": ">= 1.0.0"
   },
   "scripts": {
-    "postinstall": "node -e \"try { require('fs').symlinkSync(require('path').resolve('node_modules/@bower_components'), 'app/bower_components', 'junction') } catch (e) { }\""
+    "postinstall": "node -e \"try { require('fs').symlinkSync(require('path').resolve('node_modules/@bower_components'), 'app/bower_components', 'junction') } catch (e) { }\" && ls -al app/bower_components"
   }
 }

--- a/scripts/set_ci_version.sh
+++ b/scripts/set_ci_version.sh
@@ -53,6 +53,7 @@ echo "... setting version on dative package"
 sed 's/"version": "[^,]*"/"version": "'$SHORT_VERSION'"/' package.json  > output
 mv output package.json
 
+mkdir dist
 cp package.json dist/
 # echo "... setting Continuous Integration version on dative dist"
 # sed "s/\"\(version\": \"[^,]*\)\"/\1.$MINOR_VERSION\"/" dist/package.json  > output

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,7 +420,7 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
-coffee-script@>=1.0.1, coffee-script@>=1.2.0:
+coffee-script@>=1.2.0:
   version "1.12.7"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
 
@@ -694,11 +694,12 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-eco@~1.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/eco/-/eco-1.0.3.tgz#624eacd09c9795ed65d83da865375dc52464e56d"
+eco@1.1.0-rc-3:
+  version "1.1.0-rc-3"
+  resolved "https://registry.yarnpkg.com/eco/-/eco-1.1.0-rc-3.tgz#742a32c4615af705ab3e9a46b6ce5c16dbc57262"
+  integrity sha1-dCoyxGFa9wWrPppGts5cFtvFcmI=
   dependencies:
-    coffee-script ">=1.0.1"
+    coffee-script ">=1.2.0"
     strscan ">=1.0.1"
 
 entities@0.x:
@@ -1091,11 +1092,12 @@ grunt-docco@^0.3.3:
   dependencies:
     docco "~0.6.3"
 
-grunt-eco@*:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/grunt-eco/-/grunt-eco-0.1.3.tgz#4e6ba86948a1122990a7eae61c57ab961a769ed6"
+grunt-eco@0.2.0-rc.0:
+  version "0.2.0-rc.0"
+  resolved "https://registry.yarnpkg.com/grunt-eco/-/grunt-eco-0.2.0-rc.0.tgz#7037098dc60dc1fd6335c806b779ae08bbdf63e2"
+  integrity sha512-gFTF4fzWtsMthX0Bg9EGRlyGnraTAKBgPbTApgU21RHc5b006uPlKhopvGI6YFxmY4dFC/YeH34hwpMwzBmvzw==
   dependencies:
-    eco "~1.0"
+    eco "1.1.0-rc-3"
 
 grunt-exec@^0.4.6:
   version "0.4.7"


### PR DESCRIPTION
for FieldDB/FieldDB#2173

We ran into a few blockers in getting dative buiding on node 12

* eco is archived, so it took a while to find a fork that had a buildable version, it looks like this PR would have helped https://github.com/sstephenson/eco/pull/67/commits
* the master of eco had a breaking change that turned compile into a function which breaks grunt-eco https://github.com/cesine/grunt-eco/pull/1
* nodeunit maintainers are thinking about archiving it too, which means we wont be able to run eco's tests in CI to know if it still works in the future


Some docs we found about why maintainers are archiving their github projects rather than finding new maintainers: 

* npm recommends transfering it to them: https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions
* github wants to help prevent deletion
 https://github.blog/2017-11-08-archiving-repositories/#:~:text=Just%20because%20a%20repository%20isn,everyone%20(including%20repository%20owners).
* maintainers want to prevent distraction https://tommcfarlin.com/why-im-archiving-my-github-repositories/
* open prs will never be closable https://github.community/t/why-does-github-recommend-closing-issues-before-archiving-a-repository/1623